### PR TITLE
Add ride dashboard for roll models during active rides

### DIFF
--- a/src/app/api/events/[id]/dashboard/route.ts
+++ b/src/app/api/events/[id]/dashboard/route.ts
@@ -74,9 +74,9 @@ export async function GET(
       riderRsvpIds.length
         ? supabase
             .from("riders")
-            .select("id, first_name, last_name, group_id, medical_notes, media_opt_out")
+            .select("id, first_name, last_name, group_id, date_of_birth, medical_notes, media_opt_out")
             .in("id", riderRsvpIds)
-        : Promise.resolve({ data: [] as { id: string; first_name: string; last_name: string; group_id: string | null; medical_notes: string | null; media_opt_out: boolean }[] }),
+        : Promise.resolve({ data: [] as { id: string; first_name: string; last_name: string; group_id: string | null; date_of_birth: string | null; medical_notes: string | null; media_opt_out: boolean }[] }),
       supabase
         .from("profiles")
         .select("id, full_name, avatar_url, medical_alerts, media_opt_out, roles, rider_group_id")
@@ -190,6 +190,7 @@ export async function GET(
           group_id: r.group_id,
           group_name: g.name,
           is_minor: true,
+          date_of_birth: r.date_of_birth,
           status: (riderRsvpMap.get(r.id) ?? null) as string | null,
           medical_alerts: r.medical_notes,
           media_opt_out: r.media_opt_out,
@@ -206,6 +207,7 @@ export async function GET(
           group_id: r.rider_group_id,
           group_name: g.name,
           is_minor: false,
+          date_of_birth: null,
           status: (selfRsvpMap.get(r.id)?.status ?? null) as string | null,
           medical_alerts: r.medical_alerts,
           media_opt_out: r.media_opt_out,
@@ -279,7 +281,7 @@ export async function GET(
       .overlaps("roles", ["roll_model", "admin", "super_admin"]),
     supabase
       .from("riders")
-      .select("id, first_name, last_name, group_id, medical_notes, media_opt_out")
+      .select("id, first_name, last_name, group_id, date_of_birth, medical_notes, media_opt_out")
       .in("group_id", groupIds),
     supabase
       .from("profiles")
@@ -301,6 +303,7 @@ export async function GET(
     first_name: string;
     last_name: string;
     group_id: string | null;
+    date_of_birth: string | null;
     medical_notes: string | null;
     media_opt_out: boolean;
   }[]) ?? [];
@@ -381,6 +384,7 @@ export async function GET(
         group_id: r.group_id,
         group_name: g.name,
         is_minor: true,
+        date_of_birth: r.date_of_birth,
         status: (riderRsvpMap.get(r.id) ?? null) as string | null,
         medical_alerts: r.medical_notes,
         media_opt_out: r.media_opt_out,
@@ -395,6 +399,7 @@ export async function GET(
         group_id: r.rider_group_id,
         group_name: g.name,
         is_minor: false,
+        date_of_birth: null,
         status: (selfRsvpMap.get(r.id)?.status ?? null) as string | null,
         medical_alerts: r.medical_alerts,
         media_opt_out: r.media_opt_out,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { AppShell } from "@/components/layout/app-shell";
 import {
   Calendar,
@@ -11,6 +11,7 @@ import {
   GraduationCap,
   PartyPopper,
   HelpCircle,
+  LayoutDashboard,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -18,7 +19,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useUpcomingEvents } from "@/hooks/use-events";
 import { useAuth } from "@/hooks/use-auth";
 import { useMyRsvpsBulk } from "@/hooks/use-rsvp";
+import { useActiveRide } from "@/hooks/use-active-ride";
 import { EventCard } from "@/components/events/event-card";
+import { RideDashboard } from "@/components/events/ride-dashboard";
 import type { EventWithGroups } from "@/types";
 import Link from "next/link";
 
@@ -60,6 +63,10 @@ export default function DashboardPage() {
 
   const todayEvent = useMemo(() => findTodayEvent(upcomingEvents), [upcomingEvents]);
 
+  const isRM = hasRole("roll_model");
+  const activeRide = useActiveRide(isRM ? profile?.id : undefined);
+  const [showRideDashboard, setShowRideDashboard] = useState(false);
+
   const isLoading = authLoading || eventsLoading;
 
   return (
@@ -75,6 +82,15 @@ export default function DashboardPage() {
               : "Welcome to everybody.bike"}
           </p>
         </div>
+
+        {/* Ride Dashboard (Roll Models only, when active ride is in window) */}
+        {isRM && showRideDashboard && activeRide && profile && (
+          <RideDashboard
+            event={activeRide}
+            profile={profile}
+            onClose={() => setShowRideDashboard(false)}
+          />
+        )}
 
         {/* Stats */}
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -158,6 +174,19 @@ export default function DashboardPage() {
                     <ArrowRight className="mr-2 h-4 w-4" />
                     RSVP to Next Event
                   </Link>
+                </Button>
+              )}
+              {isRM && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-start"
+                  disabled={!activeRide}
+                  onClick={() => setShowRideDashboard((v) => !v)}
+                  title={!activeRide ? "No ride within 30 minutes" : undefined}
+                >
+                  <LayoutDashboard className="mr-2 h-4 w-4" />
+                  {showRideDashboard && activeRide ? "Hide Ride Dashboard" : "Show Ride Dashboard"}
                 </Button>
               )}
               {hasRole("parent") && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,7 +65,9 @@ export default function DashboardPage() {
 
   const isRM = hasRole("roll_model");
   const activeRide = useActiveRide(isRM ? profile?.id : undefined);
-  const [showRideDashboard, setShowRideDashboard] = useState(false);
+  // Default ON: when an active ride is detected, the dashboard shows automatically.
+  // The X in the card header (or this toggle) hides it.
+  const [showRideDashboard, setShowRideDashboard] = useState(true);
 
   const isLoading = authLoading || eventsLoading;
 

--- a/src/components/events/ride-dashboard.tsx
+++ b/src/components/events/ride-dashboard.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { X, Users, Bike } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SafetyIndicators } from "@/components/safety/safety-indicators";
+import { DashboardRatioIndicator } from "@/components/events/dashboard-ratio-indicator";
+import { useEventDashboard } from "@/hooks/use-event-dashboard";
+import { useMyRsvps } from "@/hooks/use-rsvp";
+import { useMyRollModelGroupIds } from "@/hooks/use-my-roll-model-groups";
+import { getAgeFromDob } from "@/lib/age";
+import type { EventWithGroups, Profile, DashboardRiderEntry, DashboardRollModel } from "@/types";
+
+interface RideDashboardProps {
+  event: EventWithGroups;
+  profile: Profile;
+  onClose: () => void;
+}
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+function RiderRow({ rider }: { rider: DashboardRiderEntry }) {
+  const age = rider.is_minor ? getAgeFromDob(rider.date_of_birth) : null;
+  return (
+    <li className="flex items-center gap-2 py-0.5">
+      <span className="flex-1 text-sm">
+        {rider.name}
+        {age !== null && (
+          <span className="ml-1 text-xs text-muted-foreground">· {age}y</span>
+        )}
+      </span>
+      <SafetyIndicators
+        medicalAlerts={rider.medical_alerts}
+        mediaOptOut={rider.media_opt_out}
+      />
+    </li>
+  );
+}
+
+function RollModelRow({ rm, isSelf }: { rm: DashboardRollModel; isSelf: boolean }) {
+  return (
+    <li className="flex items-center gap-2 py-0.5">
+      <span className="flex-1 text-sm">
+        {rm.full_name}
+        {isSelf && <span className="ml-1 text-xs text-muted-foreground">(you)</span>}
+      </span>
+      <SafetyIndicators
+        medicalAlerts={rm.medical_alerts}
+        mediaOptOut={rm.media_opt_out}
+      />
+    </li>
+  );
+}
+
+export function RideDashboard({ event, profile, onClose }: RideDashboardProps) {
+  const { data: dashboard, isLoading } = useEventDashboard(event.id);
+  const { data: myRsvp } = useMyRsvps(event.id, profile.id);
+  const { data: defaultGroupIds } = useMyRollModelGroupIds(profile.id);
+
+  // Resolve which group this RM is assigned to for this ride
+  const assignedGroupId: string | null =
+    myRsvp?.selfRsvp?.assigned_group_id ??
+    (defaultGroupIds?.[0] ?? null);
+
+  const assignedGroupEntry = dashboard?.riders_by_group.find(
+    (g) => g.group.id === assignedGroupId,
+  );
+
+  const allRMs = [
+    ...(dashboard?.roll_models.confirmed ?? []),
+    ...(dashboard?.roll_models.maybe ?? []),
+  ];
+
+  // RMs in the same group (excluding self)
+  const fellowRMs = assignedGroupId
+    ? allRMs.filter(
+        (rm) => rm.assigned_group_id === assignedGroupId && rm.id !== profile.id,
+      )
+    : [];
+
+  // Self in RM list (to show in header area)
+  const selfRM = allRMs.find((rm) => rm.id === profile.id);
+
+  const startsAt = formatTime(event.starts_at);
+  const endsAt = event.ends_at ? ` – ${formatTime(event.ends_at)}` : "";
+  const isInProgress = new Date() >= new Date(event.starts_at);
+
+  const groupName =
+    assignedGroupEntry?.group.name ??
+    (assignedGroupId ? "Your Group" : null);
+
+  return (
+    <Card className="border-primary/40 bg-card">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <div className="flex items-center gap-2">
+              <Bike className="h-4 w-4 text-primary" />
+              <CardTitle className="text-base">{event.title}</CardTitle>
+              <Badge variant={isInProgress ? "default" : "secondary"} className="text-xs">
+                {isInProgress ? "In Progress" : "Starting Soon"}
+              </Badge>
+            </div>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {startsAt}{endsAt}
+              {groupName && (
+                <>
+                  {" · "}
+                  <span className="font-medium text-foreground">{groupName}</span>
+                </>
+              )}
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            onClick={onClose}
+            aria-label="Hide Ride Dashboard"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4 pt-0">
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        ) : !assignedGroupId ? (
+          <p className="text-sm text-muted-foreground">
+            No group assigned yet — ask an admin to assign you for this ride.
+          </p>
+        ) : (
+          <>
+            {/* Ratio */}
+            {assignedGroupEntry && (
+              <DashboardRatioIndicator
+                ratio={assignedGroupEntry.coach_rider_ratio}
+                confirmedRollModels={assignedGroupEntry.coach_counts.confirmed}
+                confirmedRiders={assignedGroupEntry.confirmed.length}
+              />
+            )}
+
+            <Separator />
+
+            {/* Roll Models in group */}
+            <section>
+              <h3 className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <Users className="h-3.5 w-3.5" />
+                Roll Models in {groupName}
+              </h3>
+              <ul className="space-y-0.5">
+                {selfRM && <RollModelRow rm={selfRM} isSelf />}
+                {fellowRMs.length > 0
+                  ? fellowRMs.map((rm) => (
+                      <RollModelRow key={rm.id} rm={rm} isSelf={false} />
+                    ))
+                  : !selfRM && (
+                      <li className="text-sm text-muted-foreground">No roll models assigned</li>
+                    )}
+                {fellowRMs.length === 0 && selfRM && (
+                  <li className="text-xs text-muted-foreground">No other roll models in this group</li>
+                )}
+              </ul>
+            </section>
+
+            <Separator />
+
+            {/* Riders by RSVP status (exclude "no") */}
+            {assignedGroupEntry ? (
+              <section className="space-y-3">
+                {(
+                  [
+                    {
+                      label: "Coming",
+                      riders: assignedGroupEntry.confirmed,
+                      variant: "default" as const,
+                    },
+                    {
+                      label: "Maybe",
+                      riders: assignedGroupEntry.maybe,
+                      variant: "secondary" as const,
+                    },
+                    {
+                      label: "Not responded",
+                      riders: assignedGroupEntry.not_responded,
+                      variant: "outline" as const,
+                    },
+                  ] satisfies { label: string; riders: DashboardRiderEntry[]; variant: "default" | "secondary" | "outline" }[]
+                ).map(({ label, riders, variant }) =>
+                  riders.length > 0 ? (
+                    <div key={label}>
+                      <h4 className="mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                        <Badge variant={variant} className="text-xs">
+                          {label}
+                        </Badge>
+                        <span className="text-xs text-muted-foreground">
+                          {riders.length}
+                        </span>
+                      </h4>
+                      <ul className="divide-y divide-border">
+                        {riders.map((rider) => (
+                          <RiderRow key={rider.id} rider={rider} />
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null,
+                )}
+                {assignedGroupEntry.confirmed.length === 0 &&
+                  assignedGroupEntry.maybe.length === 0 &&
+                  assignedGroupEntry.not_responded.length === 0 && (
+                    <p className="text-sm text-muted-foreground">
+                      No riders in this group yet.
+                    </p>
+                  )}
+              </section>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No riders found for this group.
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/use-active-ride.ts
+++ b/src/hooks/use-active-ride.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMemo, useState, useEffect } from "react";
+import { useEvents } from "@/hooks/use-events";
+import { useMyRsvpsBulk } from "@/hooks/use-rsvp";
+import type { EventWithGroups } from "@/types";
+
+const WINDOW_BEFORE_MS = 30 * 60 * 1000; // 30 minutes
+const FALLBACK_DURATION_MS = 4 * 60 * 60 * 1000; // 4 hours
+const PAST_WINDOW_MS = 6 * 60 * 60 * 1000; // look back 6 hours for in-progress rides
+
+function isInActiveWindow(event: EventWithGroups, now: Date): boolean {
+  const startsAt = new Date(event.starts_at);
+  const endsAt = event.ends_at
+    ? new Date(event.ends_at)
+    : new Date(startsAt.getTime() + FALLBACK_DURATION_MS);
+  const windowOpen = new Date(startsAt.getTime() - WINDOW_BEFORE_MS);
+  return now >= windowOpen && now <= endsAt;
+}
+
+export function useActiveRide(userId: string | undefined) {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  // Fetch rides in [now - 6h, now + 31min] to catch both in-progress and imminent rides
+  const from = useMemo(
+    () => new Date(now.getTime() - PAST_WINDOW_MS).toISOString(),
+    [now],
+  );
+  const to = useMemo(
+    () => new Date(now.getTime() + WINDOW_BEFORE_MS + 60_000).toISOString(),
+    [now],
+  );
+
+  const { data: candidateEvents } = useEvents({ from, to, type: "ride" });
+
+  const rideEventIds = useMemo(
+    () => (candidateEvents ?? []).map((e) => e.id),
+    [candidateEvents],
+  );
+
+  const { data: rsvpMap } = useMyRsvpsBulk(rideEventIds, userId);
+
+  const activeRide = useMemo<EventWithGroups | null>(() => {
+    if (!candidateEvents || !rsvpMap) return null;
+    const sorted = [...candidateEvents].sort((a, b) =>
+      a.starts_at.localeCompare(b.starts_at),
+    );
+    for (const event of sorted) {
+      const selfRsvp = rsvpMap[event.id]?.selfRsvp;
+      if (!selfRsvp || selfRsvp.status === "no") continue;
+      if (isInActiveWindow(event, now)) return event;
+    }
+    return null;
+  }, [candidateEvents, rsvpMap, now]);
+
+  return activeRide;
+}

--- a/src/lib/age.ts
+++ b/src/lib/age.ts
@@ -1,0 +1,12 @@
+export function getAgeFromDob(dob: string | null | undefined): number | null {
+  if (!dob) return null;
+  const birth = new Date(dob);
+  if (isNaN(birth.getTime())) return null;
+  const now = new Date();
+  let age = now.getFullYear() - birth.getFullYear();
+  const monthDiff = now.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) {
+    age--;
+  }
+  return age;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -107,6 +107,7 @@ export interface DashboardRiderEntry {
   group_id: string | null;
   group_name: string;
   is_minor: boolean;
+  date_of_birth: string | null;
   status: string | null;
   medical_alerts: string | null;
   media_opt_out: boolean;


### PR DESCRIPTION
## Summary
This PR adds a real-time ride dashboard component that displays to roll models when they have an active ride within 30 minutes of starting. The dashboard shows group assignments, fellow roll models, rider RSVPs, and safety indicators.

## Key Changes

- **New `RideDashboard` component** (`src/components/events/ride-dashboard.tsx`): Displays active ride information including:
  - Event title, time, and assigned group
  - Coach-to-rider ratio indicator
  - Roll models assigned to the same group
  - Riders organized by RSVP status (Coming, Maybe, Not responded)
  - Safety indicators (medical alerts, media opt-out) for all participants
  - Age display for minor riders

- **New `useActiveRide` hook** (`src/hooks/use-active-ride.ts`): Intelligently detects active rides by:
  - Fetching rides within a 6-hour lookback and 30-minute lookahead window
  - Filtering for rides where the user has a confirmed or maybe RSVP
  - Checking if the ride is within the active window (30 minutes before start through end time)
  - Updating every 60 seconds to reflect current time

- **Dashboard integration** (`src/app/page.tsx`):
  - Added ride dashboard display for roll models only
  - Auto-shows when an active ride is detected
  - Added toggle button to show/hide the dashboard
  - Button is disabled when no active ride exists

- **API enhancement** (`src/app/api/events/[id]/dashboard/route.ts`):
  - Added `date_of_birth` field to rider data for age calculation

- **Utility function** (`src/lib/age.ts`): Helper to calculate age from date of birth

- **Type updates** (`src/types/index.ts`): Added `date_of_birth` field to `DashboardRiderEntry`

## Implementation Details

- The dashboard automatically appears when a roll model has an active ride and can be dismissed via the X button or toggle
- Age is only displayed for minor riders (those with a date of birth)
- The active ride detection uses a 30-minute pre-event window to show the dashboard before rides start
- Roll models see their own name marked as "(you)" in the group member list
- The component handles loading states and displays appropriate messaging when no group is assigned

https://claude.ai/code/session_01SWMRpDbJaSxqm6fE2m8dWA